### PR TITLE
Add `--useragent` to set user agent

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ const argsDef = [
   { name: 'quality',  alias: 'q', type: Number,  description: `The quality of the image, between 0-100. Not applicable to png images.${EOL}` },
   { name: 'width',    alias: 'w', type: Number,  description: `Viewport width in pixels \n[italic]{Default: 800}${EOL}` },
   { name: 'height',   alias: 'h', type: Number,  description: `Viewport height in pixels \n[italic]{Default: 600}${EOL}` },
+  { name: 'useragent',            type: String,  description: `The user agent of the browser \n[italic]{Default: undefined}${EOL}` },
   { name: 'timeout',              type: Number,  description: `Maximum time to wait for in milliseconds. \n[italic]{Default: 30000}${EOL}` },
   { name: 'fullPage', alias: 'f', type: Boolean, description: `When true, takes a screenshot of the full scrollable page. \n[italic]{Defaults: false}.${EOL}` },
   { name: 'noheadless',           type: Boolean, description: `Allow disabling headless mode. \n[italic]{Default: false}${EOL}` },
@@ -32,6 +33,7 @@ const doCapture = async function doCapture ({
   selector = 'body',
   width = 800,
   height = 600,
+  useragent = undefined,
   timeout = 30000,
   fullPage = false,
 }) {
@@ -41,6 +43,10 @@ const doCapture = async function doCapture ({
   page.setDefaultNavigationTimeout(timeout);
 
   try {
+    if (useragent) {
+      await page.setUserAgent(useragent);
+    }
+
     await page.setViewport({ width, height });
 
     await page.goto(url, { waitUntil: ['load', 'networkidle0'] });


### PR DESCRIPTION
Some websites like Twitter use user agent to show a different template.

![ua vs no-ua-fs8](https://user-images.githubusercontent.com/486818/106213074-fc635600-61dc-11eb-9541-5bbf30437036.png)
